### PR TITLE
added swagger docs for endpoints I implemented

### DIFF
--- a/src/controllers/user.controller.js
+++ b/src/controllers/user.controller.js
@@ -341,3 +341,45 @@ exports.getFriends = async (req, res) => {
     res.status(500).json({ error: 'Failed to fetch friends.' });
   }
 };
+
+// Subscription related endpoints
+exports.getSubscription = async (req, res) => {
+  try {
+    const user = await User.findById(req.params.id).select('subscription');
+
+    if (!user) {
+      return res.status(404).json({ message: 'User not found' });
+    }
+
+    res.status(200).json({ subscription: user.subscription });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Server error' });
+  }
+};
+
+exports.updateSubscription = async (req, res) => {
+  const { tier } = req.body;
+
+  if (!['basic', 'pro'].includes(tier)) {
+    return res.status(400).json({ message: 'Invalid subscription tier' });
+  }
+
+  try {
+    const user = await User.findById(req.params.id);
+
+    if (!user) {
+      return res.status(404).json({ message: 'User not found' });
+    }
+
+    user.subscription.tier = tier;
+    await user.save();
+
+    res.status(200).json({ message: 'Subscription updated', subscription: user.subscription });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Server error' });
+  }
+};
+
+

--- a/src/models/user.model.js
+++ b/src/models/user.model.js
@@ -35,6 +35,15 @@ const userSchema = new Schema({
     trim: true,
   },
 
+  // Basic subscription tier implementation
+  subscription: {
+    tier: {
+      type: String,
+      enum: ['basic', 'pro'],
+      default: 'basic',
+    }
+  },
+
   // Musician Profile
   profile: {
     instruments: [{

--- a/src/routes/message.routes.js
+++ b/src/routes/message.routes.js
@@ -2,6 +2,143 @@ const express = require('express');
 const router = express.Router();
 const messageController = require('../controllers/message.controller');
 
+//Swagger docs
+//Message schema
+/**
+ * @openapi
+ * components:
+ *   schemas:
+ *     MessageDoc:
+ *       type: object
+ *       properties:
+ *         _id: { type: string }
+ *         session: { type: string }
+ *         sender: { type: string }
+ *         content: { type: string, maxLength: 2000 }
+ *         createdAt: { type: string, format: date-time }
+ *         updatedAt: { type: string, format: date-time }
+ *
+ *     MessageResponse:
+ *       type: object
+ *       properties:
+ *         content: { type: string }
+ *         sender: { type: string, description: "Sender name or ID" }
+ *         timeSent: { type: string, format: date-time }
+ *
+ */
+
+//endpoint docs
+
+/**
+ * @openapi
+ * /api/sessions/{id}/messages:
+ *   get:
+ *     summary: Get messages for a session
+ *     description: Returns oldest-first chat messages for the given session. If none, returns an empty list with an informational message.
+ *     tags: [Messages]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema: { type: string }
+ *         description: Session ID (Mongo ObjectId)
+ *     responses:
+ *       200:
+ *         description: Messages retrieved.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: "SUCCESS: Session messages retrieved."
+ *                 messages:
+ *                   type: array
+ *                   items:
+ *                     $ref: "#/components/schemas/MessageResponse"
+ *       400:
+ *         description: Session ID missing.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message: { type: string }
+ *       500:
+ *         description: Server error.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message: { type: string }
+ *   post:
+ *     summary: Send a message in a session
+ *     description: Creates a new message in the specified session.
+ *     tags: [Messages]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema: { type: string }
+ *         description: Session ID (Mongo ObjectId)
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [senderId, content]
+ *             properties:
+ *               senderId:
+ *                 type: string
+ *                 description: "User ObjectId of the sender"
+ *               content:
+ *                 type: string
+ *                 maxLength: 2000
+ *     responses:
+ *       201:
+ *         description: Message created.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: "SUCCESS: Message sent successfully."
+ *                 data:
+ *                   $ref: "#/components/schemas/MessageDoc"
+ *       400:
+ *         description: Missing/invalid fields.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message: { type: string }
+ *       404:
+ *         description: Session not found.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message: { type: string }
+ *       500:
+ *         description: Server error.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message: { type: string }
+ */
+
+
+
+
 // Endpoints
 // Session message routes
 router.get('/sessions/:id/messages', messageController.getSessionMessages);

--- a/src/routes/session.routes.js
+++ b/src/routes/session.routes.js
@@ -2,6 +2,181 @@ const express = require('express');
 const router = express.Router();
 const sessionController = require('../controllers/session.controller');
 
+// Swagger docs
+// session schema
+/**
+ * @openapi
+ * components:
+ *   schemas:
+ *     Session:
+ *       type: object
+ *       properties:
+ *         _id: { type: string, description: "Mongo ObjectId" }
+ *         title: { type: string }
+ *         description: { type: string, nullable: true }
+ *         host: { type: string, description: "User ObjectId" }
+ *         isPublic: { type: boolean }
+ *         status:
+ *           type: string
+ *           enum: [Scheduled, Ongoing, Finished, Cancelled]
+ *         startTime: { type: string, format: date-time }
+ *         endTime: { type: string, format: date-time, nullable: true }
+ *         location: { type: string, nullable: true }
+ *         genre: { type: string, nullable: true }
+ *         skillLevel:
+ *           type: string
+ *           enum: [Any, Beginner, Intermediate, Advanced]
+ *         instrumentsNeeded:
+ *           type: array
+ *           items: { type: string }
+ *         spotifyPlaylistUrl: { type: string, nullable: true }
+ *         attendees:
+ *           type: array
+ *           items: { type: string }
+ *         invitedUsers:
+ *           type: array
+ *           items: { type: string }
+ *         createdAt: { type: string, format: date-time }
+ *         updatedAt: { type: string, format: date-time }
+ *
+ *     VisibilityGetResponse:
+ *       type: object
+ *       properties:
+ *         visibility: { type: boolean, description: "true if public" }
+ *
+ *     VisibilityChangeRequest:
+ *       type: object
+ *       required: [sessionId, isPublic]
+ *       properties:
+ *         sessionId: { type: string, description: "Session ObjectId" }
+ *         isPublic: { type: boolean }
+ */
+
+//endpoint docs
+/**
+ * @openapi
+ * /api/sessions/{id}/visibility:
+ *   get:
+ *     summary: Get session visibility
+ *     tags: [Sessions]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema: { type: string }
+ *     responses:
+ *       200:
+ *         description: Visibility state.
+ *         content:
+ *           application/json:
+ *             schema: { $ref: "#/components/schemas/VisibilityGetResponse" }
+ *       400: { description: Session ID missing }
+ *       404: { description: Session not found }
+ *       500: { description: Server error }
+ */
+
+/**
+ * @openapi
+ * /api/sessions/visibility:
+ *   post:
+ *     summary: Set session visibility
+ *     tags: [Sessions]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema: { $ref: "#/components/schemas/VisibilityChangeRequest" }
+ *     responses:
+ *       200: { description: Visibility updated }
+ *       400: { description: Invalid payload }
+ *       404: { description: Session not found }
+ *       500: { description: Server error }
+ *   put:
+ *     summary: Update session visibility
+ *     tags: [Sessions]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema: { $ref: "#/components/schemas/VisibilityChangeRequest" }
+ *     responses:
+ *       200: { description: Visibility updated }
+ *       400: { description: Invalid payload }
+ *       404: { description: Session not found }
+ *       500: { description: Server error }
+ */
+
+/**
+ * @openapi
+ * /api/sessions/{id}/complete:
+ *   post:
+ *     summary: Mark session as complete
+ *     tags: [Sessions]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema: { type: string }
+ *     responses:
+ *       200:
+ *         description: Session marked complete.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message: { type: string }
+ *                 session: { $ref: "#/components/schemas/Session" }
+ *       404: { description: Session not found }
+ *       500: { description: Server error }
+ */
+
+/**
+ * @openapi
+ * /api/sessions/active:
+ *   get:
+ *     summary: List active sessions
+ *     tags: [Sessions]
+ *     responses:
+ *       200:
+ *         description: Active sessions.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items: { $ref: "#/components/schemas/Session" }
+ *       500: { description: Server error }
+ *
+ * /api/sessions/upcoming:
+ *   get:
+ *     summary: List upcoming sessions
+ *     tags: [Sessions]
+ *     responses:
+ *       200:
+ *         description: Upcoming sessions.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items: { $ref: "#/components/schemas/Session" }
+ *       500: { description: Server error }
+ *
+ * /api/sessions/past:
+ *   get:
+ *     summary: List past sessions
+ *     tags: [Sessions]
+ *     responses:
+ *       200:
+ *         description: Past sessions.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items: { $ref: "#/components/schemas/Session" }
+ *       500: { description: Server error }
+ */
+
+
 // Endpoints
 // TODO: Route all endpoints
 
@@ -9,6 +184,16 @@ const sessionController = require('../controllers/session.controller');
 
 router.get('/sessions', sessionController.getAllSessions);
 router.post('/sessions', sessionController.createSession);
+
+// Session visibility
+router.get('/sessions/:id/visibility', sessionController.getVisibility);
+router.post('/sessions/visibility', sessionController.setVisibility);
+router.put('/sessions/visibility', sessionController.updateVisibility);
+
+// Session listing
+router.get('/sessions/active', sessionController.getActiveSessions);
+router.get('/sessions/upcoming', sessionController.getUpcomingSessions);
+router.get('/sessions/past', sessionController.getPastSessions);
 
 // Session by id
 router.get('/sessions/:id', sessionController.getSessionById);
@@ -20,17 +205,7 @@ router.get('/sessions/:id/participants', sessionController.getSessionParticipant
 router.post('/sessions/:id/participants', sessionController.addUserToSession);
 router.delete('/sessions/:id/participants/:userId', sessionController.removeUserFromSession);
 
-// Session visibility
-router.get('/sessions/:id/visibility', sessionController.getVisibility);
-router.post('/sessions/visibility', sessionController.setVisibility);
-router.put('/sessions/visibility', sessionController.updateVisibility);
-
 // Session state
 router.post('/sessions/:id/complete', sessionController.markComplete);
-
-// Session listing
-router.get('/sessions/active', sessionController.getActiveSessions);
-router.get('/sessions/upcoming', sessionController.getUpcomingSessions);
-router.get('/sessions/past', sessionController.getPastSessions);
 
 module.exports = router;

--- a/src/routes/user.routes.js
+++ b/src/routes/user.routes.js
@@ -16,5 +16,7 @@ router.put('/users/:id/unfriend', userController.removeFriend);
 router.get('/users/:id/friends', userController.getFriends);
 router.post('/users/:id/sessions', userController.addSessionToUser);
 router.delete('/users/:id/sessions/:sessionId', userController.removeSessionFromUser);
+router.get('/users/:id/subscription', userController.getSubscription);
+router.put('/users/:id/subscription', userController.updateSubscription);
 
 module.exports = router;


### PR DESCRIPTION
I added swagger schema for sessions at the top of session.routes.js that can be referenced for future session docs as well as one for the visibility endpoints. A similar schema has been defined for messages as well in the appropriate file.